### PR TITLE
Доработки экспорта

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,12 @@ setup(
     url='https://www.verme.ru/',
     author='Ilya Tabakov',
     author_email='i.tabakov@verme.ru',
+    install_requires=[
+        'social-auth-app-django',
+        'xlrd',
+        'XlsxWriter',
+        'xlwt',
+    ],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/xlsexport/models.py
+++ b/xlsexport/models.py
@@ -155,7 +155,7 @@ class ExportTemplate(models.Model):
                         # msg = f"Поле {field.get('field')} отсутствует в объекте"
                         # return HttpResponse(msg)
                         attr_value = None
-                if not attr_value:
+                if not attr_value and attr_value is not False:  # Output False explicitly
                     attr_value = ''
                 if isinstance(attr_value, date):
                     if param_fields and field.get('format'):
@@ -238,7 +238,7 @@ class ExportTemplate(models.Model):
                         # msg = f"Поле {field.get('field')} отсутствует в объекте"
                         # return HttpResponse(msg)
                         attr_value = None
-                if not attr_value:
+                if not attr_value and attr_value is not False:  # Output False explicitly
                     attr_value = ''
                 if isinstance(attr_value, date):
                     if param_fields and field.get('format'):

--- a/xlsexport/models.py
+++ b/xlsexport/models.py
@@ -152,8 +152,9 @@ class ExportTemplate(models.Model):
                         for x in range(1, len(field_name)):
                             attr_value = getattr(attr_value, field_name[x])
                     except AttributeError:
-                        msg = f"Поле {field.get('field')} отсутствует в объекте"
-                        return HttpResponse(msg)
+                        # msg = f"Поле {field.get('field')} отсутствует в объекте"
+                        # return HttpResponse(msg)
+                        attr_value = None
                 if not attr_value:
                     attr_value = ''
                 if isinstance(attr_value, date):
@@ -234,8 +235,9 @@ class ExportTemplate(models.Model):
                         for x in range(1, len(field_name)):
                             attr_value = getattr(attr_value, field_name[x])
                     except AttributeError:
-                        msg = f"Поле {field.get('field')} отсутствует в объекте"
-                        return HttpResponse(msg)
+                        # msg = f"Поле {field.get('field')} отсутствует в объекте"
+                        # return HttpResponse(msg)
+                        attr_value = None
                 if not attr_value:
                     attr_value = ''
                 if isinstance(attr_value, date):


### PR DESCRIPTION
- Разрешен экспорт через шаблоны, включающие поле со ссылкой на другую модель, в случае если это поле пустое. Вместо ошибки в интерфейсе выводится пустая строка в ячейку.
- Для полей, содержащих булевы значения, False теперь выводится явно вместо пустой строки. Раньше в случае обязательного поля нельзя было загрузить только что выгруженный файл, содержащий пустые строки вместо False
- В setup.py добавлены зависимости приложений. Теперь их не требуется указывать в `requirements.txt` проекта.